### PR TITLE
#958 -- Adjust frosted background component to less opacity if browser does not support blur.

### DIFF
--- a/stories/Utilities/FrostedImage/frosted-background.scss
+++ b/stories/Utilities/FrostedImage/frosted-background.scss
@@ -31,7 +31,7 @@
       @extend %frosted-bg;
     }
     img {
-      opacity: 1 !important;
+      opacity: 1;
     }
   } 
 }

--- a/stories/Utilities/FrostedImage/frosted-background.scss
+++ b/stories/Utilities/FrostedImage/frosted-background.scss
@@ -8,7 +8,7 @@
   position: relative;
 
   &::before {
-    background: rgba(247, 247, 247, 0.8);
+    background: rgba(247, 247, 247, 0.9);
 
     content: '';
     height: 100%;

--- a/stories/Utilities/FrostedImage/frosted-background.scss
+++ b/stories/Utilities/FrostedImage/frosted-background.scss
@@ -8,7 +8,7 @@
   position: relative;
 
   &::before {
-    @extend %frosted-bg;
+    background: rgba(247, 247, 247, 0.8);
 
     content: '';
     height: 100%;
@@ -20,7 +20,19 @@
   img {
     display: block;
     object-fit: cover;
+    opacity: 0.5;
   }
 }
 
+// If backdrop filter (blur) is supported, than apply the blurring effects.
+@supports (-webkit-backdrop-filter: none) or (backdrop-filter: none) {
+  .frosted-background {  
+    &::before {
+      @extend %frosted-bg;
+    }
+    img {
+      opacity: 1 !important;
+    }
+  } 
+}
 /* frosted-backfround end */

--- a/stories/assets/scss/_mixins.scss
+++ b/stories/assets/scss/_mixins.scss
@@ -165,7 +165,7 @@
 %frosted-bg {
   -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
-  background: rgba(247, 247, 247, 0.8);
+  background: rgba(247, 247, 247, 0.9);
 }
 
 %footer-block {


### PR DESCRIPTION
#958 

If browser does not support blur backdrop filter effect, than adjust the opacity of the bg image.