### PR TITLE
#916 header global and country shouldnt change to tablet view for screens larger than 1024px

### DIFF
--- a/stories/Components/Navigationcomponents/Mainnavigation/CountrySiteHeader/country-site-header.scss
+++ b/stories/Components/Navigationcomponents/Mainnavigation/CountrySiteHeader/country-site-header.scss
@@ -20,8 +20,8 @@
       font-size: $font-size-16;
       line-height: 1.142;
       margin-top: -0.25rem;
+      margin-right: 1.5rem;
       padding: 0.438rem 0;
-      width: calc(100% - 52px);
 
       @include devicebreak(mediumonlytab) {
         width: calc(100% - 64px);
@@ -82,20 +82,40 @@
     }
 
     .menu {
-      align-items: center;
+      align-items: stretch;
       align-self: stretch;
       display: flex;
       min-height: 7.1875rem;
+      margin: auto;
 
       @include devicebreak(mediumonlytab) {
         display: none;
       }
 
+      ul {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: row;
+      }
+
       li {
-        margin: $spacing-04 0 $spacing-04 3.6875rem;
+        margin: 0 0 0 2.25rem;
+        display: flex;
+        align-items: stretch;
+        align-self: stretch;
+
+        @include devicebreak(xlarge) {
+          margin: 0 0 0 3.6875rem;
+        }
 
         &:first-of-type {
           margin-left: 0;
+        }
+
+        a {
+          display: flex;
+          align-items: center;
         }
       }
     }

--- a/stories/Components/Navigationcomponents/Mainnavigation/CountrySiteHeader/country-site-header.scss
+++ b/stories/Components/Navigationcomponents/Mainnavigation/CountrySiteHeader/country-site-header.scss
@@ -215,6 +215,9 @@
     }
 
     .site-title {
+      margin-left: 1.5rem;
+      margin-right: 0;
+
       @include devicebreak(xlarge) {
         margin-left: $spacing-07;
         margin-right: 0;
@@ -240,7 +243,11 @@
 
     .menu {
       li {
-        margin: $spacing-04 3.6875rem $spacing-04 0;
+        margin: 0 2.25rem 0 0;
+
+        @include devicebreak(xlarge) {
+          margin: 0 0 0 3.6875rem;
+        }
 
         &:first-of-type {
           margin-right: 0;

--- a/stories/Components/Navigationcomponents/Mainnavigation/GlobalHeader/global-header.scss
+++ b/stories/Components/Navigationcomponents/Mainnavigation/GlobalHeader/global-header.scss
@@ -18,7 +18,13 @@
     }
 
     .top-left {
+      margin-bottom: 7px;
+      @include devicebreak(xlarge) {
+        margin-bottom: 0;
+      }
+
       @include devicebreak(mediumonlytab) {
+        margin-bottom: 0;
         display: flex;
 
         .dropdown-language {
@@ -49,15 +55,19 @@
       ul {
         @include transform(translateY(-50%));
 
-        align-items: center;
+        align-items: stretch;
         display: flex;
         height: 100%;
         left: 50%;
-        padding-left: 4.375rem;
+        padding-left: 3.375rem;
         position: absolute;
         top: 50%;
         width: 50%;
         z-index: 9;
+
+        @include devicebreak(xlarge) {
+          padding-left: 4.375rem;
+        }
 
         @include devicebreak(mediumonlytab) {
           display: none;
@@ -67,12 +77,31 @@
           justify-content: right;
           left: inherit;
           padding-left: 0;
-          padding-right: 4.375rem;
+          padding-right: 3.375rem;
           right: 50%;
+
+          @include devicebreak(xlarge) {
+            padding-right: 4.375rem;
+          }
         }
 
         li {
-          margin: 0 2.1875rem;
+          margin: 0 1.5rem;
+          display: flex;
+          align-items: stretch;
+
+          @include devicebreak(xlarge) {
+            margin: 0 2.1875rem;
+          }
+
+          a {
+            display: flex;
+            align-items: center;
+            margin-top: -15px;
+            @include devicebreak(xlarge) {
+              margin-top: 0;
+            }
+          }
         }
       }
 
@@ -109,8 +138,13 @@
     .top-right {
       display: flex;
       justify-content: flex-end;
+      margin-bottom: 15px;
+      @include devicebreak(xlarge) {
+        margin-bottom: 0;
+      }
 
       @include devicebreak(mediumonlytab) {
+        margin-bottom: 0;
         .icon-globe {
           display: none;
         }

--- a/stories/assets/scss/_breakpoints.scss
+++ b/stories/assets/scss/_breakpoints.scss
@@ -7,9 +7,10 @@
   }
 
   @else if $point==mediumonlytab {
+
     /* medium design tab */
-    @media (max-width: 89.9375em) {
-      @content;
+    @media (max-width: 63.9375em) {
+       @content;
     }
   }
 
@@ -21,14 +22,14 @@
   }
 
   @else if $point==large {
-    /* medium design */
+    /* large design */
     @media (min-width: 64em) {
       @content;
     }
   }
 
   @else if $point==xlarge {
-    /* large design */
+    /* xlarge design */
     @media (min-width: 90em) {
       @content;
     }

--- a/stories/assets/scss/_mixins.scss
+++ b/stories/assets/scss/_mixins.scss
@@ -150,6 +150,7 @@
   margin-right: $spacing-03;
   padding: 0;
   width: 25px;
+  min-width: 25px;
 
   @include devicebreak(small) {
     margin-right: 0;
@@ -600,12 +601,10 @@
 
 %logo {
   @include transition(all 0.4s cubic-bezier(0.64, 0.05, 0.35, 1.05));
-
-  width: 40px;
+  min-width: 60px;
 
   @include devicebreak(xlarge) {
     height: ($header-height-xlarge + 7px);
-    width: 60px;
 
     &.scrolled {
       height: $header-height-xlarge;
@@ -614,6 +613,7 @@
 
   @include devicebreak(mediumonlytab) {
     height: ($header-height-medium + 7px);
+    min-width: 40px;
 
     &.scrolled {
       height: $header-height-medium;


### PR DESCRIPTION
#916 #915 
Country and Global headers shouldn't change to tablet/mobile layout until it's <1024px.
Also addresses some glitchyness with the mega menu popup trigger (Issue #915)