### PR TITLE
#924 if image is followed by text there should be a space in between

### DIFF
--- a/stories/Atom/Images/ImageCaptionCredit/image-caption-credit.scss
+++ b/stories/Atom/Images/ImageCaptionCredit/image-caption-credit.scss
@@ -10,10 +10,10 @@
     justify-content: center;
 
     .image__caption {
-      margin: $spacing-05 $spacing-06 0;
+      margin: $spacing-05 $spacing-06 $spacing-07;
 
       @include devicebreak(medium) {
-        margin: $spacing-07 0 0;
+        margin: $spacing-07 0 $spacing-07;
         width: 58.33333%;
       }
     }


### PR DESCRIPTION
#924

Applied a margin bottom to a figcaption in an image component to space it from following items.