### PR TITLE
#985 -- Set the arrow to render by default on CTA buttons without option set

### DIFF
--- a/stories/Components/UIcomponents/Buttons/CtaButton/CtaButton.jsx
+++ b/stories/Components/UIcomponents/Buttons/CtaButton/CtaButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './buttons.scss';
 import '../../../../Atom/Icons/icons.scss';
 
-export const for_primary_options = {
+export const icon_options = {
   'No Arrow': 'without-arrow',
   Arrow: 'arrow',
   Download: 'download',
@@ -13,14 +13,17 @@ export function CtaButton({
   label,
   Type,
   State,
-  For_Primary,
+  Icon,
   ...props
 }) {
   const cls = (...classes) => ((classes.filter(Boolean).length > 0) ? classes.filter(Boolean).join(' ') : null);
   const type = (Type == 'Secondary') ? 'secondary' : 'primary';
   const state = (State == 'Disabled') ? 'disabled' : '';
-  const for_primary = For_Primary ? for_primary_options[`${For_Primary}`] : for_primary_options.Arrow;
-  const classes = cls('button', `button-${type}`, `button-${for_primary}`, `${state}`);
+
+  let default_icon = (Type == 'Secondary') ? icon_options['No Arrow'] : icon_options.Arrow;
+  let icon = Icon ? icon_options[`${Icon}`] : default_icon;
+
+  const classes = cls('button', `button-${type}`, `button-${icon}`, `${state}`);
 
   return (
     <a
@@ -30,10 +33,10 @@ export function CtaButton({
       {...props}
     >
       {label}
-      {For_Primary == 'External link' && (
+      {Icon == 'External link' && (
         <span className="external-link-animated"><i /></span>
       )}
-      {For_Primary == 'Download' && (
+      {Icon == 'Download' && (
         <span className="download-animated"><i /></span>
       )}
     </a>

--- a/stories/Components/UIcomponents/Buttons/CtaButton/CtaButton.jsx
+++ b/stories/Components/UIcomponents/Buttons/CtaButton/CtaButton.jsx
@@ -19,7 +19,7 @@ export function CtaButton({
   const cls = (...classes) => ((classes.filter(Boolean).length > 0) ? classes.filter(Boolean).join(' ') : null);
   const type = (Type == 'Secondary') ? 'secondary' : 'primary';
   const state = (State == 'Disabled') ? 'disabled' : '';
-  const for_primary = for_primary_options[`${For_Primary}`];
+  const for_primary = For_Primary ? for_primary_options[`${For_Primary}`] : for_primary_options.Arrow;
   const classes = cls('button', `button-${type}`, `button-${for_primary}`, `${state}`);
 
   return (

--- a/stories/Components/UIcomponents/Buttons/CtaButton/CtaButton.stories.mdx
+++ b/stories/Components/UIcomponents/Buttons/CtaButton/CtaButton.stories.mdx
@@ -24,14 +24,17 @@ export const getCaptionForLocale = (locale) => {
   title="Components/UI components/Buttons/Buttons"
   argTypes={{
     Type: {
+      name: "Type",
       options: ["Primary", "Secondary"],
       control: { type: "inline-radio" },
     },
     State: {
+      name: "State",
       options: ["Active", "Disabled"],
       control: { type: "inline-radio" },
     },
-    For_Primary: {
+    Icon: {
+      name: "Icon",
       options: ["Arrow", "No Arrow", "Download", "External link"],
       control: { type: "inline-radio" },
     },
@@ -39,7 +42,7 @@ export const getCaptionForLocale = (locale) => {
   args={{
     Type: "Primary",
     State: "Active",
-    For_Primary: "Arrow",
+    Icon: "Arrow",
   }}
 />
 

--- a/stories/Organism/Blocks/FeaturedContentCard/PagewideContentCard/PageWideCard.jsx
+++ b/stories/Organism/Blocks/FeaturedContentCard/PagewideContentCard/PageWideCard.jsx
@@ -28,7 +28,7 @@ export function PageWideCard({
             <Heading type="4" label={title} />
             <P label={paragraph} />
           </div>
-          <CtaButton label={button} for_primary="arrow" />
+          <CtaButton label={button} Icon="Arrow" />
         </div>
         <div className={cls('cell medium-6 wide-card__image', `${hovercolors_variant}`)}>
           <a href="#">

--- a/stories/Patterns/DownloadModal/DownloadModal.jsx
+++ b/stories/Patterns/DownloadModal/DownloadModal.jsx
@@ -20,9 +20,16 @@ export const Category_options = {
   Multiplelanguages: '',
 };
 
-export const DownloadModal = ({
-  data, button, select, modalbtn, content, Image, Category, ...props
-}) => {
+export function DownloadModal({
+  data,
+  button,
+  select,
+  modalbtn,
+  content,
+  Image,
+  Category,
+  ...props
+}) {
   useEffect(() => {
     checkbox('.form-check input', '.download-footer .button-primary');
     selectFilter();
@@ -33,16 +40,16 @@ export const DownloadModal = ({
   return (
     <>
       {content === '' && <CtaButton label={modalbtn} data-toggle="modal" data-target-modal="#downloadModal" />}
-      <Modal 
+      <Modal
         id="downloadModal"
         css_class={image_variant}
-        content={
+        content={(
           <>
             <div className="download-body">
               {Image === 'True' && (
-              <div className="show-large">
-                <Publicationthumb Hovercolors="yellow" />
-              </div>
+                <div className="show-large">
+                  <Publicationthumb Hovercolors="yellow" />
+                </div>
               )}
               <div className="download-content">
                 {Category === 'Multiplelanguages' && <CustomSelect text={select} />}
@@ -54,16 +61,11 @@ export const DownloadModal = ({
               </div>
             </div>
             <div className="download-footer">
-              <CtaButton label={button} For_Primary="No Arrow" State="Disabled" />
-            </div>  
+              <CtaButton label={button} Type="Primary" Icon="Download" State="Disabled" />
+            </div>
           </>
-        }
+        )}
       />
     </>
   );
-};
-
-DownloadModal.defaultProps = {
-  Image: 'True',
-  Category: 'Multiplelanguages',
-};
+}

--- a/stories/Patterns/DownloadModal/DownloadModal.stories.mdx
+++ b/stories/Patterns/DownloadModal/DownloadModal.stories.mdx
@@ -1,451 +1,480 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs';
-import { DownloadModal } from './DownloadModal';
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { DownloadModal } from "./DownloadModal";
 
 export const statsArray = (locale) => {
-  switch(locale) {
-    case 'english': const engText = {data: [{
-      title: 'Title of the publication quite long - Pasto',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'Title of the publication quite long - Pasto',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'Title of the publication quite long - Pasto',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'Title of the publication quite long - Dari',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'Title of the publication quite long - Dari',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'Title of the publication quite long - Dari',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'Title of the publication quite long - English',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'Title of the publication quite long - English',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'Title of the publication quite long - English',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'Title of the publication quite long - Albanian',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'Title of the publication quite long - Albanian',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'Title of the publication quite long - Albanian',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'Title of the publication quite long - Arabic',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'arabic'
-    },
-    {
-      title: 'Title of the publication quite long - Arabic',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'arabic'
-    },
-    {
-      title: 'Title of the publication quite long - Portuguese',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'portuguese'
-    },
-    {
-      title: 'Title of the publication quite long - Portuguese',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'portuguese'
-    }],
-    button: 'DOWNLOAD',
-    select: 'Select language',
-    modalbtn: 'Modal',
-    content: ''
-    }; return engText;
-    case 'arabic': const arabicText = {data: [{
-      title: 'عنوان المنشور طويل جدا - باستو',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - باستو',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - باستو',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - داري',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'dari'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - داري',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'dari'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - داري',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'dari'
-    },
-    {
-      title: 'عنوان المنشور طويل جدًا - إنجليزي',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'en'
-    },
-    {
-      title: 'عنوان المنشور طويل جدًا - إنجليزي',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'en'
-    },
-    {
-      title: 'عنوان المنشور طويل جدًا - إنجليزي',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'en'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - ألباني',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - ألباني',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - ألباني',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - عربي',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'arabic'
-    },
-    {
-      title: 'عنوان المنشور طويل جدا - عربي',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'arabic'
-    },
-    {
-      title: 'عنوان المنشور طويل جدًا - برتغالي',
-      subtitle: 'PDF (1.2)ميجابايت',
-      dataValue: 'portuguese'
-    },
-    {
-      title: 'عنوان المنشور طويل جدًا - برتغالي',
-      subtitle: 'PDF (1.2) ميجابايت',
-      dataValue: 'portuguese'
-    }],
-    button: 'تحميل',
-    select: 'اختار اللغة',
-    modalbtn: 'مشروط',
-    content: ''
-    }; return arabicText;
-    case 'burmese': const burmeseText = {data: [{
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ခေါက်ဆွဲ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ခေါက်ဆွဲ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ခေါက်ဆွဲ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ဒါ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ဒါ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ဒါ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အင်္ဂလိပ်',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အင်္ဂလိပ်',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အင်္ဂလိပ်',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အယ်လ်ဘေးနီးယန်း',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အယ်လ်ဘေးနီးယန်း',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အယ်လ်ဘေးနီးယန်း',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အာရဗီ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'arabic'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အာရဗီ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'arabic'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ပေါ်တူဂီ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'portuguese'
-    },
-    {
-      title: 'စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ပေါ်တူဂီ',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'portuguese'
-    }],
-    button: 'ဒေါင်းလုဒ်လုပ်ပါ။',
-    select: 'ဘာသာစကားကို ရွေးပါ။',
-    modalbtn: 'မော်ဒယ်',
-    content: ''
-    }; return burmeseText;
-    case 'japanese': const japaneseText = {data: [{
-      title: '出版物のタイトルはかなり長い - パスト',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - パスト',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - パスト',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - ダリー語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - ダリー語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - ダリー語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - 英語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - 英語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - 英語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - アルバニア語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - アルバニア語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - アルバニア語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - アラビア語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'arabic'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - アラビア語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'arabic'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - -ポルトガル語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'portuguese'
-    },
-    {
-      title: '出版物のタイトルはかなり長い - -ポルトガル語',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'portuguese'
-    }],
-    button: 'ダウンロード',
-    select: '言語を選択する',
-    modalbtn: 'モーダル',
-    content: ''
-    }; return japaneseText;
+  switch (locale) {
+    case "english":
+      const engText = {
+        data: [
+          {
+            title: "Title of the publication quite long - Pasto",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "Title of the publication quite long - Pasto",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "Title of the publication quite long - Pasto",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "Title of the publication quite long - Dari",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "Title of the publication quite long - Dari",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "Title of the publication quite long - Dari",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "Title of the publication quite long - English",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "Title of the publication quite long - English",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "Title of the publication quite long - English",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "Title of the publication quite long - Albanian",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "Title of the publication quite long - Albanian",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "Title of the publication quite long - Albanian",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "Title of the publication quite long - Arabic",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "arabic",
+          },
+          {
+            title: "Title of the publication quite long - Arabic",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "arabic",
+          },
+          {
+            title: "Title of the publication quite long - Portuguese",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "portuguese",
+          },
+          {
+            title: "Title of the publication quite long - Portuguese",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "portuguese",
+          },
+        ],
+        button: "DOWNLOAD",
+        select: "Select language",
+        modalbtn: "Modal",
+        content: "",
+      };
+      return engText;
+    case "arabic":
+      const arabicText = {
+        data: [
+          {
+            title: "عنوان المنشور طويل جدا - باستو",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "pasto",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - باستو",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "pasto",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - باستو",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "pasto",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - داري",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "dari",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - داري",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "dari",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - داري",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "dari",
+          },
+          {
+            title: "عنوان المنشور طويل جدًا - إنجليزي",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "en",
+          },
+          {
+            title: "عنوان المنشور طويل جدًا - إنجليزي",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "en",
+          },
+          {
+            title: "عنوان المنشور طويل جدًا - إنجليزي",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "en",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - ألباني",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "albanian",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - ألباني",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "albanian",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - ألباني",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "albanian",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - عربي",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "arabic",
+          },
+          {
+            title: "عنوان المنشور طويل جدا - عربي",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "arabic",
+          },
+          {
+            title: "عنوان المنشور طويل جدًا - برتغالي",
+            subtitle: "PDF (1.2)ميجابايت",
+            dataValue: "portuguese",
+          },
+          {
+            title: "عنوان المنشور طويل جدًا - برتغالي",
+            subtitle: "PDF (1.2) ميجابايت",
+            dataValue: "portuguese",
+          },
+        ],
+        button: "تحميل",
+        select: "اختار اللغة",
+        modalbtn: "مشروط",
+        content: "",
+      };
+      return arabicText;
+    case "burmese":
+      const burmeseText = {
+        data: [
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ခေါက်ဆွဲ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ခေါက်ဆွဲ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ခေါက်ဆွဲ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ဒါ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ဒါ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ဒါ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အင်္ဂလိပ်",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အင်္ဂလိပ်",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အင်္ဂလိပ်",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အယ်လ်ဘေးနီးယန်း",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အယ်လ်ဘေးနီးယန်း",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အယ်လ်ဘေးနီးယန်း",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အာရဗီ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "arabic",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - အာရဗီ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "arabic",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ပေါ်တူဂီ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "portuguese",
+          },
+          {
+            title: "စာအုပ်ခေါင်းစဉ်က တော်တော်ရှည်တယ်။ - ပေါ်တူဂီ",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "portuguese",
+          },
+        ],
+        button: "ဒေါင်းလုဒ်လုပ်ပါ။",
+        select: "ဘာသာစကားကို ရွေးပါ။",
+        modalbtn: "မော်ဒယ်",
+        content: "",
+      };
+      return burmeseText;
+    case "japanese":
+      const japaneseText = {
+        data: [
+          {
+            title: "出版物のタイトルはかなり長い - パスト",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - パスト",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - パスト",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - ダリー語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - ダリー語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - ダリー語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - 英語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - 英語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - 英語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - アルバニア語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - アルバニア語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - アルバニア語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - アラビア語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "arabic",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - アラビア語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "arabic",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - -ポルトガル語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "portuguese",
+          },
+          {
+            title: "出版物のタイトルはかなり長い - -ポルトガル語",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "portuguese",
+          },
+        ],
+        button: "ダウンロード",
+        select: "言語を選択する",
+        modalbtn: "モーダル",
+        content: "",
+      };
+      return japaneseText;
     default:
-    const dummy =  {data: [{
-      title: 'Title of the publication quite long - Pasto',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'Title of the publication quite long - Pasto',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'Title of the publication quite long - Pasto',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'pasto'
-    },
-    {
-      title: 'Title of the publication quite long - Dari',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'Title of the publication quite long - Dari',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'Title of the publication quite long - Dari',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'dari'
-    },
-    {
-      title: 'Title of the publication quite long - English',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'Title of the publication quite long - English',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'Title of the publication quite long - English',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'en'
-    },
-    {
-      title: 'Title of the publication quite long - Albanian',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'Title of the publication quite long - Albanian',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'Title of the publication quite long - Albanian',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'albanian'
-    },
-    {
-      title: 'Title of the publication quite long - Arabic',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'arabic'
-    },
-    {
-      title: 'Title of the publication quite long - Arabic',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'arabic'
-    },
-    {
-      title: 'Title of the publication quite long - Portuguese',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'portuguese'
-    },
-    {
-      title: 'Title of the publication quite long - Portuguese',
-      subtitle: 'PDF (1.2MB)',
-      dataValue: 'portuguese'
-    }],
-    button: 'DOWNLOAD',
-    select: 'Select language',
-    modalbtn: 'Modal',
-    content: ''
-    };
-    return dummy
+      const dummy = {
+        data: [
+          {
+            title: "Title of the publication quite long - Pasto",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "Title of the publication quite long - Pasto",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "Title of the publication quite long - Pasto",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "pasto",
+          },
+          {
+            title: "Title of the publication quite long - Dari",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "Title of the publication quite long - Dari",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "Title of the publication quite long - Dari",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "dari",
+          },
+          {
+            title: "Title of the publication quite long - English",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "Title of the publication quite long - English",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "Title of the publication quite long - English",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "en",
+          },
+          {
+            title: "Title of the publication quite long - Albanian",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "Title of the publication quite long - Albanian",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "Title of the publication quite long - Albanian",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "albanian",
+          },
+          {
+            title: "Title of the publication quite long - Arabic",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "arabic",
+          },
+          {
+            title: "Title of the publication quite long - Arabic",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "arabic",
+          },
+          {
+            title: "Title of the publication quite long - Portuguese",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "portuguese",
+          },
+          {
+            title: "Title of the publication quite long - Portuguese",
+            subtitle: "PDF (1.2MB)",
+            dataValue: "portuguese",
+          },
+        ],
+        button: "DOWNLOAD",
+        select: "Select language",
+        modalbtn: "Modal",
+        content: "",
+      };
+      return dummy;
   }
 };
 
-<Meta title="Patterns/Download modal"
+<Meta
+  title="Patterns/Download modal"
   argTypes={{
     Image: {
+      name: "Display image",
       options: ["True", "False"],
-      control: { type: "radio" },
-      defaultValue: "True"
+      control: { type: "inline-radio" },
     },
     Category: {
+      name: "Category",
       options: ["Singlelanguage", "Multiplelanguages"],
-      control: { type: "radio" },
-      defaultValue: "Multiplelanguages"
-    }
-  }}/>
+      control: { type: "inline-radio" },
+    },
+  }}
+  args={{
+    Image: "True",
+    Category: "Multiplelanguages",
+  }}
+/>
 
 # Download Modal
 
@@ -468,6 +497,7 @@ In this, the user will be given a list where he can select one or more assets to
 ### Behaviors
 
 #### States
+
 There are two state for download modal: Default and Select
 Default: In this, the user will be given options to choose the language for downloading the document. When no checkboxes are checked - The download button is in a disabled state.
 
@@ -479,12 +509,23 @@ Close button dismisses the entire modal window and resets filter states and chec
   <Story name="Download modal">
     {(args, { globals: { locale } }) => {
       const caption = statsArray(locale);
-      return <DownloadModal data={caption.data} button={caption.button} select={caption.select} id="downloadModal" modalbtn={caption.modalbtn} content={caption.content} {...args}></DownloadModal>;
+      return (
+        <DownloadModal
+          data={caption.data}
+          button={caption.button}
+          select={caption.select}
+          id="downloadModal"
+          modalbtn={caption.modalbtn}
+          content={caption.content}
+          {...args}
+        ></DownloadModal>
+      );
     }}
   </Story>
 </Canvas>
 
 ### Usage
+
 - Choose the image either true or false and Category either Single or Multiple Languages from the control tab on canvas.
 - Grab the HTML from the HTML tab in the canvas and include css and js files listed below.
 - Make sure to add data-toggle='modal' and data-target-modal='&lt;your-modal-id&gt;' in your button or link which will open the modal box.
@@ -508,12 +549,15 @@ Add the base layout style from
 - https://undp.github.io/design-system/css/components/download-row.min.css
 
 #### JS
+
 - https://undp.github.io/design-system/js/modal.min.js.
 - https://undp.github.io/design-system/js/select.min.js.
 - https://undp.github.io/design-system/js/download-modal.min.js.
 
 ### Interactions
+
 There will be a checkbox where the user can click on it to select the asset and then click on the download button to download the document.
 
 ### Changelog
+
 1.0 — Released component

--- a/stories/Templates/CountryHomepage/CountryHomepage.jsx
+++ b/stories/Templates/CountryHomepage/CountryHomepage.jsx
@@ -12,7 +12,7 @@ import { Footer } from '../../Organism/Footer/Footer';
 import './countryhome-page.scss';
 import { CtaButton } from '../../Components/UIcomponents/Buttons/CtaButton/CtaButton';
 
-export const CountryHomepage = ({
+export function CountryHomepage({
   footerData,
   herotitle,
   herotext,
@@ -47,8 +47,9 @@ export const CountryHomepage = ({
   headingTop,
   takeAcrtionHead,
   storyBtn,
-  statdata
-}) => (
+  statdata,
+}) {
+  return (
     <>
       <CountrySiteHeader
         siteTitleData={siteTitleData}
@@ -89,7 +90,7 @@ export const CountryHomepage = ({
         </div>
         <div className="grid-x wide-card-heading">
           <div className="cell small-12 medium-12 large-11 large-offset-1">
-            <Heading type="2" label={storiesHeading} dataViewport="true"/>
+            <Heading type="2" label={storiesHeading} dataViewport="true" />
           </div>
           <PageWideCard
             label={PagewidecardTag}
@@ -105,7 +106,7 @@ export const CountryHomepage = ({
           dataViewport="true"
         />
         <div className="cell cta-container">
-          <CtaButton label={storyBtn} For_Primary="No Arrow" />
+          <CtaButton label={storyBtn} Icon="No Arrow" />
         </div>
         <div className="grid-x our-impact">
           <div className="cell small-12 medium-12 large-11 large-offset-1" data-viewport="true">
@@ -115,10 +116,10 @@ export const CountryHomepage = ({
             <StatsSlider data={statdata} />
           </div>
         </div>
-          <ImageRevealCards
-            data={takeactioncard.data}
-            label={takeAcrtionHead}
-          />
+        <ImageRevealCards
+          data={takeactioncard.data}
+          label={takeAcrtionHead}
+        />
       </div>
 
       <Footer
@@ -144,3 +145,4 @@ export const CountryHomepage = ({
       />
     </>
   );
+}


### PR DESCRIPTION
Referencing this last issue found after merging last PR - https://github.com/undp/design-system/pull/1129#issuecomment-1437504308

@theadamparker - I set the CTA button to use the arrow by default if no icon option is set. 
The arrow default was altered when the download and external link icon options were added. This PR changes it back to show the arrow by default.