### PR TITLE
(fix) issue #1375 -- header size dynamically adjusted

### DIFF
--- a/stories/Atom/Typography/Heading/Heading.jsx
+++ b/stories/Atom/Typography/Heading/Heading.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import '../../../assets/scss/_typography.scss';
+import React from "react";
+import "../../../assets/scss/_typography.scss";
 
 export function Heading({
   type,
@@ -14,8 +14,26 @@ export function Heading({
   const heading_classes = className ?? '';
 
   return (
-    <HeadingTag className={heading_classes} tabIndex={tab_index} data-viewport={data_viewport}>
+    <HeadingTag className={heading_classes} tabIndex={tab_index} data-viewport={data_viewport} style={{ fontSize: `${getSize()}vw` }}>
       {label}
     </HeadingTag>
   );
+
+  function getSize() {
+    const MAX_SIZE = 8;
+    // there are more words
+    if (label.indexOf(' ') !== -1) {
+      return 4; // 4vw
+    }
+
+    // => there is only one word
+    if (label.length < 5) {
+      return 8; // 8vw
+    }
+
+    const WORD_LENGTH = label.length;
+    const WORD_SIZE = WORD_LENGTH * (0.88 ** WORD_LENGTH);
+    if (WORD_SIZE > MAX_SIZE) return MAX_SIZE;
+    return WORD_SIZE;
+  }
 }

--- a/stories/Components/UIcomponents/Hero/PageHero/PageHeroOption.jsx
+++ b/stories/Components/UIcomponents/Hero/PageHero/PageHeroOption.jsx
@@ -27,7 +27,7 @@ export function PageHeroOption({
           <div className="pagehero-content color-black">
             <Breadcrumbcomponent data={data} />
             {args.Overline == 'On' && content && <Heading type="4" label={content} dataViewport="true" />}
-            <Heading type="2" label={title} dataViewport="true" />
+            <Heading type="2" label={title} className="title" dataViewport="true" />
             {args.Subtitle == 'On' && subtitle && <p className="subtitle">{subtitle}</p>}
             {args.CTA == 'On' && cta.label && <CtaButton label={cta.label} For_Primary={cta.for_primary} />}
           </div>
@@ -39,7 +39,7 @@ export function PageHeroOption({
             ) : (
               <picture>
                 <source media="(min-width: 767px)" srcSet={imgsrc} />
-                <img 
+                <img
                 src={imgsrc2} alt={imgalt} />
               </picture>
             )}


### PR DESCRIPTION
## 🚀 (fix) issue #1375 -- header size dynamically adjusted

### Issue
"The size of the header is computed with a mathematical function and passed further to react. This way the header does not wrap around for single words that are long. However, it still wraps around for phrases."

### Solution

With this PR, the size of the header is computed with a mathematical function and passed further to react. This way, the header does not wrap around for long single words; the functionality of text wrapping around for phrases is still maintained.

See appendix below.

### Type of Change

Please check the relevant options:

- [X] 🐛 Bug fix (non-breaking change)
- [ ] ✨ New feature (non-breaking change)
- [ ] ⚠️ Breaking change
- [ ] 📚 Documentation update

This activity is supported by the [Network Institute](https://networkinstitute.org/), Vrije Universiteit Amsterdam, under the Code for Humanity initiative.


## Appendix

### Initially
<img width="1459" alt="Screenshot 2024-09-17 at 7 48 22 PM" src="https://github.com/user-attachments/assets/c75e1d09-f5ca-4444-bbd3-1015ad1f73cc">

### Text from template
<img width="1477" alt="Screenshot 2024-09-17 at 8 32 32 PM" src="https://github.com/user-attachments/assets/1b18a93b-6c75-4b7e-9268-16fce190e859">

### 4 letter word (<5 threshold)
<img width="1472" alt="Screenshot 2024-09-17 at 8 32 52 PM" src="https://github.com/user-attachments/assets/9563e9a1-99af-4d33-b87e-e11bf72e9820">

### >=5 letter-threshold
<img width="1475" alt="Screenshot 2024-09-17 at 8 32 59 PM" src="https://github.com/user-attachments/assets/89a1e7d4-f312-4ceb-9912-0c8e22638ccd">

### 14 letter word (3% of the English words have >=letters, 0.02% have >=14 letters)
<img width="1473" alt="Screenshot 2024-09-17 at 8 33 10 PM" src="https://github.com/user-attachments/assets/432641de-c972-497b-beaf-736209f2038c">

### A bit towards extreme
<img width="1473" alt="Screenshot 2024-09-17 at 8 33 20 PM" src="https://github.com/user-attachments/assets/1b7d2756-ac9a-4f0d-97c9-b78652f18884">

### "ABCDE FGHIJKLM NOPQRSTU" (3 longer words)
<img width="1471" alt="Screenshot 2024-09-17 at 8 33 34 PM" src="https://github.com/user-attachments/assets/2099ac51-03b5-46b4-899d-ef2ddff60e2d">


